### PR TITLE
Fixed the reference to app_label to opts.app_label

### DIFF
--- a/djangocms_admin_style/templates/admin/delete_selected_confirmation.html
+++ b/djangocms_admin_style/templates/admin/delete_selected_confirmation.html
@@ -8,7 +8,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
-&rsaquo; <a href="{% url 'admin:app_list' app_label=app_label %}">{{ app_label|capfirst|escape }}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_label|capfirst|escape }}</a>
 &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
 &rsaquo; {% trans 'Delete multiple objects' %}
 </div>


### PR DESCRIPTION
The current state is causing a NoReverseMatch exception when trying to delete an object.
